### PR TITLE
Set shell to bash in makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+SHELL := /bin/bash
+
 LIBRARY_JSON := griptape_cloud/griptape-nodes-library.json
 
 .PHONY: version/get


### PR DESCRIPTION
Adds `SHELL := /bin/bash` to the Makefile to ensure bash is used as the shell.